### PR TITLE
[RFC]Consolidate multimodal related info

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -553,7 +553,7 @@ class ModelConfig:
             logger.info("Encoder-decoder model detected, disabling mm processor cache.")
 
         # Init multimodal config if needed
-        if self._model_info.supports_multimodal:
+        if self.model_arch_config.is_multimodal_model:
             if (
                 mm_encoder_tp_mode == "data"
                 and not self._model_info.supports_multimodal_encoder_tp_data
@@ -1374,7 +1374,7 @@ class ModelConfig:
 
     @property
     def is_multimodal_model(self) -> bool:
-        return self.multimodal_config is not None
+        return self.model_arch_config.is_multimodal_model
 
     @property
     def is_multimodal_raw_input_only_model(self) -> bool:

--- a/vllm/config/model_arch.py
+++ b/vllm/config/model_arch.py
@@ -16,7 +16,7 @@ class ModelArchitectureConfig:
     Configuration for model architecture that required by vLLM runtime
     """
 
-    architectures: list[str] | None
+    architectures: list[str]
     """List of model architecture class names (e.g., ['LlamaForCausalLM']).
        It can be None upon calling `vllm_config.with_hf_config(config.text_config)`"""
 

--- a/vllm/config/model_arch.py
+++ b/vllm/config/model_arch.py
@@ -55,3 +55,6 @@ class ModelArchitectureConfig:
 
     derived_max_model_len_and_key: tuple[float, str | None]
     """Derived maximum model length and key from the hf config."""
+
+    is_multimodal_model: bool
+    """Whether the model is a multimodal model."""

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -444,7 +444,6 @@ class VllmConfig:
 
         model_config = copy.deepcopy(self.model_config)
         model_config.hf_config = hf_config
-        model_config.model_arch_config = model_config.get_model_arch_config()
 
         return replace(self, model_config=model_config)
 

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -241,6 +241,10 @@ class ModelArchConfigConvertorBase:
             derived_max_model_len = tmp_max_len
         return derived_max_model_len, max_len_key
 
+    def is_multimodal_model(self) -> bool:
+        model_cls = ModelRegistry._try_load_model_cls(model_arch)
+        is_multimodal = supports_multimodal(model_cls)
+
     def convert(self) -> ModelArchitectureConfig:
         model_arch_config = ModelArchitectureConfig(
             architectures=self.get_architectures(),

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -247,7 +247,7 @@ class ModelArchConfigConvertorBase:
 
     def is_multimodal_model(self) -> bool:
         model_cls: type[nn.Module] | None = me_models.registry._try_load_model_cls(
-            self.get_architectures()[0]
+            self.get_architectures()[0]  # will rebase upon #31633
         )
         assert model_cls is not None, (
             f"Unknown model architecture: {self.get_architectures()}"

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -1,22 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import final
+from typing import TYPE_CHECKING, final
 
 import torch
+import torch.nn as nn
 from safetensors.torch import _TYPES as _SAFETENSORS_TO_TORCH_DTYPE
 from transformers import PretrainedConfig
 
 from vllm import envs
-from vllm.config.model_arch import (
-    ModelArchitectureConfig,
-)
+from vllm.config.model_arch import ModelArchitectureConfig
 from vllm.config.utils import getattr_iter
 from vllm.logger import init_logger
-from vllm.transformers_utils.config import (
-    try_get_safetensors_metadata,
-)
+from vllm.transformers_utils.config import try_get_safetensors_metadata
+from vllm.utils.import_utils import LazyLoader
 from vllm.utils.torch_utils import common_broadcastable_dtype
+
+if TYPE_CHECKING:
+    import vllm.model_executor.models as me_models
+else:
+    me_models = LazyLoader("model_executor", globals(), "vllm.model_executor.models")
+
 
 logger = init_logger(__name__)
 
@@ -242,8 +246,13 @@ class ModelArchConfigConvertorBase:
         return derived_max_model_len, max_len_key
 
     def is_multimodal_model(self) -> bool:
-        model_cls = ModelRegistry._try_load_model_cls(model_arch)
-        is_multimodal = supports_multimodal(model_cls)
+        model_cls: type[nn.Module] | None = me_models.registry._try_load_model_cls(
+            self.get_architectures()[0]
+        )
+        assert model_cls is not None, (
+            f"Unknown model architecture: {self.get_architectures()}"
+        )
+        return model_cls.supports_multimodal
 
     def convert(self) -> ModelArchitectureConfig:
         model_arch_config = ModelArchitectureConfig(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
There are some discussion about where shall we put the multimodal related info
https://github.com/vllm-project/vllm/issues/24384#issuecomment-3489703720 suggested that we should put `supports_multimodal` into `model_arch_config` as it's something purely from model architecture.

Later I found `ModelConfig` also has `supports_multimodal_raw_input_only`, but I'm hesitate about whether to put it into `model_arch_config`, as it's something related to vLLM..
https://github.com/vllm-project/vllm/blob/0a7dd23754ed5e01303e0eb4e64ace5e70251f46/vllm/config/model.py#L1407




## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

